### PR TITLE
package name lowercased in generated code

### DIFF
--- a/versioninfo.go
+++ b/versioninfo.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -42,7 +43,7 @@ const PkgVersion = %s
 `,
 		generatedBy, time.Now().Format(time.ANSIC),
 		strconv.Quote(vi.Branch), vi.Build,
-		pkgName,
+		strings.ToLower(pkgName),
 		strconv.Quote(pkgName),
 		strconv.QuoteToASCII(vi.Version)), nil
 }

--- a/versioninfo_test.go
+++ b/versioninfo_test.go
@@ -1,6 +1,7 @@
 package makeversion
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,9 +15,11 @@ func Test_VersionInfo_Render(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, VersionText+"\n", txt)
 
-	txt, err = vi.Render("foo")
+	txt, err = vi.Render("FooBar")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, txt)
+	assert.True(t, strings.Contains(txt, "package foobar"))
+	assert.True(t, strings.Contains(txt, "const PkgName = \"FooBar\""))
 
 	txt, err = vi.Render("123")
 	assert.Error(t, err)


### PR DESCRIPTION
This allows the `PkgName` constant to differ from the actual package name in capitalization, and lets you use a more visually striking PkgName while keeping the `package name` statement within Go guidelines.
