### PR TITLE
stretchr/testify -> matryer/is

### DIFF
--- a/environment_test.go
+++ b/environment_test.go
@@ -4,16 +4,17 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/matryer/is"
 )
 
 func Test_OsEnvironment_Getenv(t *testing.T) {
+	is := is.New(t)
 	const VarName = "MKENV_TEST3141592654"
 	env := OsEnvironment{}
 	_, expectOk := os.LookupEnv(VarName)
 	_, actualOk := env.LookupEnv(VarName)
-	assert.Equal(t, expectOk, actualOk)
+	is.Equal(expectOk, actualOk)
 	expect := os.Getenv(VarName)
 	actual := env.Getenv(VarName)
-	assert.Equal(t, expect, actual)
+	is.Equal(expect, actual)
 }

--- a/gitter_test.go
+++ b/gitter_test.go
@@ -4,42 +4,47 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/matryer/is"
 )
 
 func Test_NewDefaultGitter_SucceedsNormally(t *testing.T) {
+	is := is.New(t)
 	dg, err := NewDefaultGitter("git")
-	assert.NoError(t, err)
-	assert.NotNil(t, dg)
+	is.NoErr(err)
+	is.True(dg != nil)
 }
 
 func Test_CheckGitRepo_SuceedsForCurrent(t *testing.T) {
+	is := is.New(t)
 	repo, err := CheckGitRepo(".")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, repo)
+	is.NoErr(err)
+	is.True(repo != "")
 }
 
 func Test_CheckGitRepo_SuceedsForCmdMkver(t *testing.T) {
+	is := is.New(t)
 	repo, err := CheckGitRepo("./cmd/mkver")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, repo)
+	is.NoErr(err)
+	is.True(repo != "")
 }
 
 func Test_CheckGitRepo_FailsForRoot(t *testing.T) {
+	is := is.New(t)
 	repo, err := CheckGitRepo("/")
-	assert.Error(t, err)
-	assert.Empty(t, repo)
+	is.True(repo == "")
+	is.True(err != nil)
 }
 
 func Test_CheckGitRepo_IgnoresFileNamedGit(t *testing.T) {
+	is := is.New(t)
 	const fileNamedGit = "./cmd/mkver/.git"
 	if _, err := os.Stat(fileNamedGit); err != nil {
 		if f, err := os.Create(fileNamedGit); err == nil {
 			defer f.Close()
 			defer os.Remove(fileNamedGit)
 			repo, err := CheckGitRepo("./cmd/mkver")
-			assert.NoError(t, err)
-			assert.NotEmpty(t, repo)
+			is.NoErr(err)
+			is.True(repo != "")
 		}
 	} else {
 		t.Logf("warning: '%s' already exists\n", fileNamedGit)
@@ -47,25 +52,28 @@ func Test_CheckGitRepo_IgnoresFileNamedGit(t *testing.T) {
 }
 
 func Test_DefaultGitter_GetTag(t *testing.T) {
+	is := is.New(t)
 	dg, err := NewDefaultGitter("git")
-	if assert.NoError(t, err) && assert.NotNil(t, dg) {
-		assert.NotEmpty(t, dg.GetTag("."))
-		assert.Empty(t, dg.GetTag("/"))
-	}
+	is.NoErr(err)
+	is.True(dg != nil)
+	is.True(dg.GetTag(".") != "")
+	is.Equal(dg.GetTag("/"), "")
 }
 
 func Test_DefaultGitter_GetBranch(t *testing.T) {
+	is := is.New(t)
 	dg, err := NewDefaultGitter("git")
-	if assert.NoError(t, err) && assert.NotNil(t, dg) {
-		assert.NotEmpty(t, dg.GetBranch("."))
-		assert.Equal(t, "", dg.GetBranch("/"))
-	}
+	is.NoErr(err)
+	is.True(dg != nil)
+	is.True(dg.GetBranch(".") != "")
+	is.Equal(dg.GetBranch("/"), "")
 }
 
 func Test_DefaultGitter_GetBuild(t *testing.T) {
+	is := is.New(t)
 	dg, err := NewDefaultGitter("git")
-	if assert.NoError(t, err) && assert.NotNil(t, dg) {
-		assert.NotEmpty(t, dg.GetBuild("."))
-		assert.Empty(t, dg.GetBuild("/"))
-	}
+	is.NoErr(err)
+	is.True(dg != nil)
+	is.True(dg.GetBuild(".") != "")
+	is.Equal(dg.GetBuild("/"), "")
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/cparta/makeversion
 
 go 1.16
 
-require github.com/stretchr/testify v1.7.1
+require github.com/matryer/is v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,2 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
+github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=

--- a/versioninfo_test.go
+++ b/versioninfo_test.go
@@ -4,24 +4,25 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/matryer/is"
 )
 
 func Test_VersionInfo_Render(t *testing.T) {
+	is := is.New(t)
 	const VersionText = "v1.2.3-mybranch.456"
 	vi := &VersionInfo{Version: VersionText}
 
 	txt, err := vi.Render("")
-	assert.NoError(t, err)
-	assert.Equal(t, VersionText+"\n", txt)
+	is.NoErr(err)
+	is.Equal(VersionText+"\n", txt)
 
 	txt, err = vi.Render("FooBar")
-	assert.NoError(t, err)
-	assert.NotEmpty(t, txt)
-	assert.True(t, strings.Contains(txt, "package foobar"))
-	assert.True(t, strings.Contains(txt, "const PkgName = \"FooBar\""))
+	is.NoErr(err)
+	is.True(txt != "")
+	is.True(strings.Contains(txt, "package foobar"))
+	is.True(strings.Contains(txt, "const PkgName = \"FooBar\""))
 
 	txt, err = vi.Render("123")
-	assert.Error(t, err)
-	assert.Empty(t, txt)
+	is.True(err != nil)
+	is.Equal(txt, "")
 }

--- a/versionstringer_test.go
+++ b/versionstringer_test.go
@@ -5,7 +5,7 @@ package makeversion
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/matryer/is"
 )
 
 type MockEnvironment map[string]string
@@ -34,18 +34,21 @@ func (mg MockGitter) GetBuild(repo string) string {
 }
 
 func Test_NewVersionStringer_SucceedsNormally(t *testing.T) {
+	is := is.New(t)
 	vs, err := NewVersionStringer("git")
-	assert.NoError(t, err)
-	assert.NotNil(t, vs)
+	is.NoErr(err)
+	is.True(vs != nil)
 }
 
 func Test_NewVersionStringer_FailsWithBadBinary(t *testing.T) {
+	is := is.New(t)
 	vs, err := NewVersionStringer("./versionstringer.go")
-	assert.Error(t, err)
-	assert.Nil(t, vs)
+	is.True(err != nil)
+	is.Equal(vs, nil)
 }
 
 func Test_VersionStringer_IsEnvTrue(t *testing.T) {
+	is := is.New(t)
 	vs := VersionStringer{
 		Env: MockEnvironment{
 			"TEST_EMPTY":      "",
@@ -54,141 +57,147 @@ func Test_VersionStringer_IsEnvTrue(t *testing.T) {
 			"TEST_TRUE_UPPER": "TRUE",
 		},
 	}
-	assert.False(t, vs.IsEnvTrue("TEST_MISSING"))
-	assert.False(t, vs.IsEnvTrue("TEST_EMPTY"))
-	assert.False(t, vs.IsEnvTrue("TEST_FALSE"))
-	assert.True(t, vs.IsEnvTrue("TEST_TRUE_LOWER"))
-	assert.True(t, vs.IsEnvTrue("TEST_TRUE_UPPER"))
+	is.Equal(vs.IsEnvTrue("TEST_MISSING"), false)
+	is.Equal(vs.IsEnvTrue("TEST_MISSING"), false)
+	is.Equal(vs.IsEnvTrue("TEST_EMPTY"), false)
+	is.Equal(vs.IsEnvTrue("TEST_FALSE"), false)
+	is.Equal(vs.IsEnvTrue("TEST_TRUE_LOWER"), true)
+	is.Equal(vs.IsEnvTrue("TEST_TRUE_UPPER"), true)
 }
 
 func Test_VersionStringer_IsReleaseBranch(t *testing.T) {
+	is := is.New(t)
 	const branchName = "testbranch"
 	env := MockEnvironment{}
 	vs := VersionStringer{Env: env}
 
-	assert.True(t, vs.IsReleaseBranch("default"))
-	assert.True(t, vs.IsReleaseBranch("main"))
-	assert.True(t, vs.IsReleaseBranch("master"))
-	assert.False(t, vs.IsReleaseBranch(branchName))
+	is.True(vs.IsReleaseBranch("default"))
+	is.True(vs.IsReleaseBranch("main"))
+	is.True(vs.IsReleaseBranch("master"))
+	is.True(!vs.IsReleaseBranch(branchName))
 
 	env["CI_DEFAULT_BRANCH"] = branchName
-	assert.True(t, vs.IsReleaseBranch(branchName))
+	is.True(vs.IsReleaseBranch(branchName))
 	delete(env, "CI_DEFAULT_BRANCH")
 
 	env["CI_COMMIT_REF_PROTECTED"] = "true"
-	assert.True(t, vs.IsReleaseBranch(branchName))
+	is.True(vs.IsReleaseBranch(branchName))
 	delete(env, "CI_COMMIT_REF_PROTECTED")
 
 	env["GITHUB_REF_PROTECTED"] = "true"
-	assert.True(t, vs.IsReleaseBranch(branchName))
+	is.True(vs.IsReleaseBranch(branchName))
 	delete(env, "GITHUB_REF_PROTECTED")
 
-	assert.False(t, vs.IsReleaseBranch(branchName))
+	is.True(!vs.IsReleaseBranch(branchName))
 }
 
 func Test_VersionStringer_GetTag(t *testing.T) {
+	is := is.New(t)
 	env := MockEnvironment{}
 	git := MockGitter{}
 	vs := VersionStringer{Git: git, Env: env}
 
 	tag, err := vs.GetTag("")
-	assert.NoError(t, err)
-	assert.Equal(t, "v0.0.0", tag)
+	is.NoErr(err)
+	is.Equal("v0.0.0", tag)
 
 	tag, err = vs.GetTag("v1.2.3")
-	assert.NoError(t, err)
-	assert.Equal(t, "v1.2.3", tag)
+	is.NoErr(err)
+	is.Equal("v1.2.3", tag)
 
 	tag, err = vs.GetTag("foo")
-	assert.Error(t, err)
-	assert.Equal(t, "foo", tag)
+	is.True(err != nil)
+	is.Equal("foo", tag)
 
 	env["CI_COMMIT_TAG"] = "v3"
 	tag, err = vs.GetTag("")
-	assert.NoError(t, err)
-	assert.Equal(t, "v3", tag)
+	is.NoErr(err)
+	is.Equal("v3", tag)
 }
 
 func Test_VersionStringer_GetBranch(t *testing.T) {
+	is := is.New(t)
 	env := MockEnvironment{}
 	git := MockGitter{}
 	vs := VersionStringer{Git: git, Env: env}
 
 	text, name := vs.GetBranch("branch")
-	assert.Equal(t, "branch", name)
-	assert.Equal(t, "branch", text)
+	is.Equal("branch", name)
+	is.Equal("branch", text)
 
 	text, name = vs.GetBranch("branch.with..dots")
-	assert.Equal(t, "branch.with..dots", name)
-	assert.Equal(t, "branch-with-dots", text)
+	is.Equal("branch.with..dots", name)
+	is.Equal("branch-with-dots", text)
 
 	env["CI_COMMIT_REF_NAME"] = "gitlab-branch"
 	text, name = vs.GetBranch("")
-	assert.Equal(t, "gitlab-branch", name)
-	assert.Equal(t, "gitlab-branch", text)
+	is.Equal("gitlab-branch", name)
+	is.Equal("gitlab-branch", text)
 	delete(env, "CI_COMMIT_REF_NAME")
 
 	env["GITHUB_REF_NAME"] = "github.branch"
 	text, name = vs.GetBranch("")
-	assert.Equal(t, "github.branch", name)
-	assert.Equal(t, "github-branch", text)
+	is.Equal("github.branch", name)
+	is.Equal("github-branch", text)
 	delete(env, "GITHUB_REF_NAME")
 }
 
 func Test_VersionStringer_GetBuild(t *testing.T) {
+	is := is.New(t)
 	env := MockEnvironment{}
 	git := MockGitter{}
 	vs := VersionStringer{Git: git, Env: env}
 
 	build := vs.GetBuild("123")
-	assert.Equal(t, "123", build)
+	is.Equal("123", build)
 
 	env["CI_PIPELINE_IID"] = "456"
 	build = vs.GetBuild("")
-	assert.Equal(t, "456", build)
+	is.Equal("456", build)
 	delete(env, "CI_PIPELINE_IID")
 
 	env["GITHUB_RUN_NUMBER"] = "789"
 	build = vs.GetBuild("345")
-	assert.Equal(t, "789", build)
+	is.Equal("789", build)
 	delete(env, "CI_PIPELINE_IID")
 }
 
 func Test_VersionStringer_GetVersion(t *testing.T) {
+	is := is.New(t)
 	env := MockEnvironment{}
 	git := MockGitter{}
 	vs := VersionStringer{Git: git, Env: env}
 
 	vi, err := vs.GetVersion("v1", false)
-	assert.NoError(t, err)
-	assert.Equal(t, "v1-v1.v1", vi.Version)
+	is.NoErr(err)
+	is.Equal("v1-v1.v1", vi.Version)
 
 	vi, err = vs.GetVersion("", false)
-	assert.NoError(t, err)
-	assert.Equal(t, "v0.0.0", vi.Version)
+	is.NoErr(err)
+	is.Equal("v0.0.0", vi.Version)
 
 	env["CI_COMMIT_REF_NAME"] = "HEAD"
 	vi, err = vs.GetVersion("", false)
-	assert.NoError(t, err)
-	assert.Equal(t, "v0.0.0-HEAD", vi.Version)
+	is.NoErr(err)
+	is.Equal("v0.0.0-HEAD", vi.Version)
 
 	delete(env, "CI_COMMIT_REF_NAME")
 	env["GITHUB_RUN_NUMBER"] = "789"
 	vi, err = vs.GetVersion("", false)
-	assert.NoError(t, err)
-	assert.Equal(t, "v0.0.0-789", vi.Version)
+	is.NoErr(err)
+	is.Equal("v0.0.0-789", vi.Version)
 
 	env["CI_COMMIT_REF_NAME"] = "*Branch--.--ONE*-*"
 	env["GITHUB_RUN_NUMBER"] = "789"
 	vi, err = vs.GetVersion("v2.0", false)
-	assert.NoError(t, err)
-	assert.Equal(t, "v2.0-branch-one.789", vi.Version)
+	is.NoErr(err)
+	is.Equal("v2.0-branch-one.789", vi.Version)
 
 	vi, err = vs.GetVersion("v3.4.5", true)
-	assert.Error(t, err)
+	is.True(err != nil)
 
 	env["CI_COMMIT_REF_NAME"] = "main"
 	vi, err = vs.GetVersion("v3.4.5", true)
-	assert.NoError(t, err)
-	assert.Equal(t, "v3.4.5", vi.Version)
+	is.NoErr(err)
+	is.Equal("v3.4.5", vi.Version)
 }


### PR DESCRIPTION
Replaces the testing package in order to reduce the number of dependencies.